### PR TITLE
bt: osi: undef PROPERTY_VALUE_MAX

### DIFF
--- a/osi/include/properties.h
+++ b/osi/include/properties.h
@@ -20,6 +20,8 @@
 
 #include <cstdint>
 
+#undef PROPERTY_VALUE_MAX
+
 #define PROPERTY_VALUE_MAX 92
 #define BUILD_SANITY_PROPERTY_VALUE_MAX 92
 


### PR DESCRIPTION
Already defined in ./bionic/libc/include/sys/system_properties.h
which causes circular errors if remove from anyone of the place.

Instead, undef first & then redefine to avoid macro-redefined errors.
Change-Id: I25f761f19e71e2859c633d8250fe146f8dd1340b